### PR TITLE
Dumping request and response in exception messages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     "suggest": {
         "guzzlehttp/guzzle": "^6.0, to use the Guzzle6HttpClient adapter",
         "mtdowling/jmespath.php": "^2.0, to use the Result::search() method",
-        "psr/log": "^1.0, to use the WarningCheckingHttpClient adapter"
+        "psr/log": "^1.0, to use the WarningCheckingHttpClient adapter",
+        "monolog/monolog": "^1.0, to use the HttpMessageProcessor log processor"
     },
     "extra": {
         "branch-alias": {

--- a/src/Log/HttpMessageProcessor.php
+++ b/src/Log/HttpMessageProcessor.php
@@ -7,7 +7,7 @@ use eLife\ApiClient\Exception\HttpProblem;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\MessageInterface;
 
-class HttpMessageProcessor
+final class HttpMessageProcessor
 {
     public function __invoke(array $record)
     {

--- a/src/Log/HttpMessageProcessor.php
+++ b/src/Log/HttpMessageProcessor.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace eLife\ApiClient\Log;
+
+use eLife\ApiClient\Exception\BadResponse;
+use eLife\ApiClient\Exception\HttpProblem;
+use GuzzleHttp\Psr7;
+use Psr\Http\Message\MessageInterface;
+
+class HttpMessageProcessor
+{
+    public function __invoke(array $record)
+    {
+        if (array_key_exists('exception', $record['context'])) {
+            $exception = $record['context']['exception'];
+            if ($exception instanceof HttpProblem) {
+                $record['extra']['request'] = $this->dumpHttpMessage($exception->getRequest());
+            }
+            if ($exception instanceof BadResponse) {
+                $record['extra']['response'] = $this->dumpHttpMessage($exception->getResponse());
+            }
+        }
+
+        return $record;
+    }
+
+    private function dumpHttpMessage(MessageInterface $message)
+    {
+        return str_replace("\r", '', Psr7\str($message));
+    }
+}

--- a/test/Log/HttpMessageProcessorTest.php
+++ b/test/Log/HttpMessageProcessorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace eLife\ApiClient\Log;
+
+use eLife\ApiClient\Exception\BadResponse;
+use eLife\ApiClient\Exception\NetworkProblem;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit_Framework_TestCase;
+
+class HttpMessageProcessorTest extends PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->processor = new HttpMessageProcessor();
+    }
+
+    /**
+     * @test
+     */
+    public function it_dumps_requests()
+    {
+        $decoratedRecord = $this->processor->__invoke([
+            'context' => [
+                'exception' => new NetworkProblem(
+                    'timeout',
+                    new Request('GET', '/', ['Host' => 'example.com'])
+                ),
+            ],
+        ]);
+        $requestDump = <<<'EOT'
+GET / HTTP/1.1
+Host: example.com
+
+
+EOT;
+        $this->assertEquals($requestDump, $decoratedRecord['extra']['request']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_dumps_responses()
+    {
+        $decoratedRecord = $this->processor->__invoke([
+            'context' => [
+                'exception' => new BadResponse(
+                    'timeout',
+                    new Request('GET', '/', ['Host' => 'example.com']),
+                    new Response(200)
+                ),
+            ],
+        ]);
+        $responseDump = <<<'EOT'
+HTTP/1.1 200 OK
+
+
+EOT;
+        $this->assertEquals($responseDump, $decoratedRecord['extra']['response']);
+    }
+}


### PR DESCRIPTION
On the hypothesis that exception messages are confidential and not shown to the user but only logged, problematic requests and responses are stored there for investigation.

The heredoc syntax seems the most readable for specifying how the representation of requests and response look like. These follows the standard output of the curl command.