### PR TITLE
Proof of concept: Missing exception on 404

### DIFF
--- a/src/Exception/Missing.php
+++ b/src/Exception/Missing.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace eLife\ApiClient\Exception;
+
+use Exception;
+use RuntimeException;
+
+class Missing extends BadResponse
+{
+}

--- a/src/HttpClient/Guzzle6HttpClient.php
+++ b/src/HttpClient/Guzzle6HttpClient.php
@@ -7,6 +7,7 @@ use Crell\ApiProblem\JsonParseException;
 use eLife\ApiClient\Exception\ApiException;
 use eLife\ApiClient\Exception\ApiProblemResponse;
 use eLife\ApiClient\Exception\BadResponse;
+use eLife\ApiClient\Exception\Missing;
 use eLife\ApiClient\Exception\NetworkProblem;
 use eLife\ApiClient\HttpClient;
 use eLife\ApiClient\Result\HttpResult;
@@ -44,6 +45,8 @@ final class Guzzle6HttpClient implements HttpClient
                                 throw new BadResponse($e->getMessage(), $e->getRequest(), $e->getResponse(), $e);
                             }
                             throw new ApiProblemResponse($apiProblem, $e->getRequest(), $e->getResponse(), $e);
+                        } else if ($e->getResponse()->getStatusCode() === 404) {
+                            throw new Missing($e->getMessage(), $e->getRequest(), $e->getResponse(), $e);
                         } else {
                             throw new BadResponse($e->getMessage(), $e->getRequest(), $e->getResponse(), $e);
                         }

--- a/test/HttpClient/Guzzle6HttpClientTest.php
+++ b/test/HttpClient/Guzzle6HttpClientTest.php
@@ -6,6 +6,7 @@ use Crell\ApiProblem\ApiProblem;
 use eLife\ApiClient\Exception\ApiException;
 use eLife\ApiClient\Exception\ApiProblemResponse;
 use eLife\ApiClient\Exception\BadResponse;
+use eLife\ApiClient\Exception\Missing;
 use eLife\ApiClient\Exception\NetworkProblem;
 use eLife\ApiClient\Result\HttpResult;
 use GuzzleHttp\Client;
@@ -71,7 +72,7 @@ final class Guzzle6HttpClientTest extends PHPUnit_Framework_TestCase
     public function it_throws_response_exceptions_on_broken_api_problems()
     {
         $request = new Request('GET', 'foo');
-        $response = new Response(404, ['Content-Type' => 'application/problem+json'], 'foo bar baz');
+        $response = new Response(403, ['Content-Type' => 'application/problem+json'], 'foo bar baz');
 
         $this->mock->append($response);
 
@@ -89,13 +90,30 @@ final class Guzzle6HttpClientTest extends PHPUnit_Framework_TestCase
     {
         $request = new Request('GET', 'foo');
         $apiProblem = new ApiProblem('Problem');
-        $response = new Response(404, ['Content-Type' => 'foo/bar'], $apiProblem->asJson());
+        $response = new Response(403, ['Content-Type' => 'foo/bar'], $apiProblem->asJson());
 
         $this->mock->append($response);
 
         $client = new Guzzle6HttpClient($this->guzzle);
 
         $this->expectException(BadResponse::class);
+
+        $client->send($request)->wait();
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_missing_exceptions()
+    {
+        $request = new Request('GET', 'foo');
+        $response = new Response(404);
+
+        $this->mock->append($response);
+
+        $client = new Guzzle6HttpClient($this->guzzle);
+
+        $this->expectException(Missing::class);
 
         $client->send($request)->wait();
     }


### PR DESCRIPTION
Not sure about the approach so it's a minimal PR, spec for the exception can be added later.

It would be useful from backends consuming the API to have a specific exception when they see 404, i.e. unpublished content they received through the bus but it's not publicly available yet. We would catch this exception and log it with info level rather than error