### PR TITLE
Cater for rejections not being a Throwable

### DIFF
--- a/src/HttpClient/Guzzle6HttpClient.php
+++ b/src/HttpClient/Guzzle6HttpClient.php
@@ -16,8 +16,8 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Throwable;
 use function GuzzleHttp\default_user_agent;
+use function GuzzleHttp\Promise\exception_for;
 
 final class Guzzle6HttpClient implements HttpClient
 {
@@ -38,7 +38,9 @@ final class Guzzle6HttpClient implements HttpClient
                     return HttpResult::fromResponse($response);
                 }
             )->otherwise(
-                function (Throwable $e) {
+                function ($reason) {
+                    $e = exception_for($reason);
+
                     if ($e instanceof BadResponseException) {
                         if ('application/problem+json' === $e->getResponse()->getHeaderLine('Content-Type')) {
                             try {

--- a/test/HttpClient/Guzzle6HttpClientTest.php
+++ b/test/HttpClient/Guzzle6HttpClientTest.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit_Framework_TestCase;
@@ -156,6 +157,21 @@ final class Guzzle6HttpClientTest extends PHPUnit_Framework_TestCase
     {
         $request = new Request('GET', 'foo');
         $this->mock->append(new TransferException());
+
+        $client = new Guzzle6HttpClient($this->guzzle);
+
+        $this->expectException(ApiException::class);
+
+        $client->send($request)->wait();
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_api_exceptions_on_non_throwables()
+    {
+        $request = new Request('GET', 'foo');
+        $this->mock->append(new RejectedPromise('error'));
 
         $client = new Guzzle6HttpClient($this->guzzle);
 


### PR DESCRIPTION
Reading the Guzzle Promises spec again it's possible for rejections to be things other than a `Throwable`.

@giorgiosironi This is reason why Journal can't update `csa/guzzle-bundle`.