### PR TITLE
Add ApiTimeout exception

### DIFF
--- a/src/Exception/ApiTimeout.php
+++ b/src/Exception/ApiTimeout.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace eLife\ApiClient\Exception;
+
+class ApiTimeout extends NetworkProblem
+{
+}

--- a/src/HttpClient/Guzzle6HttpClient.php
+++ b/src/HttpClient/Guzzle6HttpClient.php
@@ -6,12 +6,14 @@ use Crell\ApiProblem\ApiProblem;
 use Crell\ApiProblem\JsonParseException;
 use eLife\ApiClient\Exception\ApiException;
 use eLife\ApiClient\Exception\ApiProblemResponse;
+use eLife\ApiClient\Exception\ApiTimeout;
 use eLife\ApiClient\Exception\BadResponse;
 use eLife\ApiClient\Exception\NetworkProblem;
 use eLife\ApiClient\HttpClient;
 use eLife\ApiClient\Result\HttpResult;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
@@ -53,6 +55,10 @@ final class Guzzle6HttpClient implements HttpClient
                             throw new BadResponse($e->getMessage(), $e->getRequest(), $e->getResponse(), $e);
                         }
                     } elseif ($e instanceof RequestException) {
+                        if ($e instanceof ConnectException && CURLE_OPERATION_TIMEOUTED === ($e->getHandlerContext()['errno'] ?? null)) {
+                            throw new ApiTimeout($e->getMessage(), $e->getRequest(), $e);
+                        }
+
                         throw new NetworkProblem($e->getMessage(), $e->getRequest(), $e);
                     }
 

--- a/test/HttpClient/Guzzle6HttpClientTest.php
+++ b/test/HttpClient/Guzzle6HttpClientTest.php
@@ -5,10 +5,12 @@ namespace eLife\ApiClient\HttpClient;
 use Crell\ApiProblem\ApiProblem;
 use eLife\ApiClient\Exception\ApiException;
 use eLife\ApiClient\Exception\ApiProblemResponse;
+use eLife\ApiClient\Exception\ApiTimeout;
 use eLife\ApiClient\Exception\BadResponse;
 use eLife\ApiClient\Exception\NetworkProblem;
 use eLife\ApiClient\Result\HttpResult;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Handler\MockHandler;
@@ -131,6 +133,21 @@ final class Guzzle6HttpClientTest extends PHPUnit_Framework_TestCase
         $client = new Guzzle6HttpClient($this->guzzle);
 
         $this->expectException(BadResponse::class);
+
+        $client->send($request)->wait();
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_api_timeout_exceptions()
+    {
+        $request = new Request('GET', 'foo');
+        $this->mock->append(new ConnectException('Problem', $request, null, ['errno' => 28, 'error' => 'Timeout']));
+
+        $client = new Guzzle6HttpClient($this->guzzle);
+
+        $this->expectException(ApiTimeout::class);
 
         $client->send($request)->wait();
     }


### PR DESCRIPTION
Will assist in https://github.com/elifesciences/journal/pull/326.

Can't see a consistent way to get a timeout from Guzzle, so this is tied to cURL.