### PR TITLE
Don't percentage-encode query string characters that don't need to be encoded

### DIFF
--- a/spec/ApiClient/SearchClientSpec.php
+++ b/spec/ApiClient/SearchClientSpec.php
@@ -25,15 +25,30 @@ final class SearchClientSpec extends ObjectBehavior
     public function it_queries()
     {
         $request = new Request('GET',
-            'search?for=foo&page=1&per-page=20&sort=date&order=desc&subject[]=cell-biology&type[]=research-article&use-date=published&start-date=2017-01-02&end-date=2017-02-03',
+            'search?for=foo/%23&page=1&per-page=20&sort=date&order=desc&subject[]=cell-biology&type[]=research-article&use-date=published&start-date=2017-01-02&end-date=2017-02-03',
             ['X-Foo' => 'bar', 'Accept' => 'application/vnd.elife.search+json; version=2', 'User-Agent' => 'eLifeApiClient/'.Version::get()]);
         $response = new FulfilledPromise(new ArrayResult(new MediaType('application/vnd.elife.search+json',
             2), ['foo' => ['bar', 'baz']]));
 
         $this->httpClient->send($request)->willReturn($response);
 
-        $this->query((['Accept' => 'application/vnd.elife.search+json; version=2']), 'foo', 1, 20, 'date', true,
+        $this->query((['Accept' => 'application/vnd.elife.search+json; version=2']), 'foo/#', 1, 20, 'date', true,
             ['cell-biology'], ['research-article'], 'published', new DateTimeImmutable('2017-01-02'), new DateTimeImmutable('2017-02-03'))
+            ->shouldBeLike($response)
+        ;
+    }
+
+    public function it_always_queries_with_for()
+    {
+        $request = new Request('GET',
+            'search?page=1&per-page=20&sort=relevance&order=desc&use-date=default&for=',
+            ['X-Foo' => 'bar', 'Accept' => 'application/vnd.elife.search+json; version=2', 'User-Agent' => 'eLifeApiClient/'.Version::get()]);
+        $response = new FulfilledPromise(new ArrayResult(new MediaType('application/vnd.elife.search+json',
+            2), ['foo' => ['bar', 'baz']]));
+
+        $this->httpClient->send($request)->willReturn($response);
+
+        $this->query((['Accept' => 'application/vnd.elife.search+json; version=2']))
             ->shouldBeLike($response)
         ;
     }

--- a/spec/ApiClient/SearchClientSpec.php
+++ b/spec/ApiClient/SearchClientSpec.php
@@ -41,7 +41,7 @@ final class SearchClientSpec extends ObjectBehavior
     public function it_always_queries_with_for()
     {
         $request = new Request('GET',
-            'search?page=1&per-page=20&sort=relevance&order=desc&use-date=default&for=',
+            'search?for=&page=1&per-page=20&sort=relevance&order=desc&use-date=default',
             ['X-Foo' => 'bar', 'Accept' => 'application/vnd.elife.search+json; version=2', 'User-Agent' => 'eLifeApiClient/'.Version::get()]);
         $response = new FulfilledPromise(new ArrayResult(new MediaType('application/vnd.elife.search+json',
             2), ['foo' => ['bar', 'baz']]));

--- a/spec/ApiClient/SearchClientSpec.php
+++ b/spec/ApiClient/SearchClientSpec.php
@@ -25,14 +25,14 @@ final class SearchClientSpec extends ObjectBehavior
     public function it_queries()
     {
         $request = new Request('GET',
-            'search?for=foo/%23&page=1&per-page=20&sort=date&order=desc&subject[]=cell-biology&type[]=research-article&use-date=published&start-date=2017-01-02&end-date=2017-02-03',
+            'search?for=foo/%23%20bar&page=1&per-page=20&sort=date&order=desc&subject[]=cell-biology&type[]=research-article&use-date=published&start-date=2017-01-02&end-date=2017-02-03',
             ['X-Foo' => 'bar', 'Accept' => 'application/vnd.elife.search+json; version=2', 'User-Agent' => 'eLifeApiClient/'.Version::get()]);
         $response = new FulfilledPromise(new ArrayResult(new MediaType('application/vnd.elife.search+json',
             2), ['foo' => ['bar', 'baz']]));
 
         $this->httpClient->send($request)->willReturn($response);
 
-        $this->query((['Accept' => 'application/vnd.elife.search+json; version=2']), 'foo/#', 1, 20, 'date', true,
+        $this->query((['Accept' => 'application/vnd.elife.search+json; version=2']), 'foo/# bar', 1, 20, 'date', true,
             ['cell-biology'], ['research-article'], 'published', new DateTimeImmutable('2017-01-02'), new DateTimeImmutable('2017-02-03'))
             ->shouldBeLike($response)
         ;

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -5,8 +5,10 @@ namespace eLife\ApiClient;
 use eLife\ApiClient\HttpClient\UserAgentPrependingHttpClient;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
+use function GuzzleHttp\Psr7\build_query;
 
 trait ApiClient
 {
@@ -57,5 +59,14 @@ trait ApiClient
         $request = new Request('PUT', $uri, $headers, $content);
 
         return $this->httpClient->send($request);
+    }
+
+    final protected function createUri(array $parts) : UriInterface
+    {
+        if (!empty($parts['query'])) {
+            $parts['query'] = build_query(array_filter($parts['query']), false);
+        }
+
+        return Uri::fromParts($parts);
     }
 }

--- a/src/ApiClient/AnnualReportsClient.php
+++ b/src/ApiClient/AnnualReportsClient.php
@@ -4,8 +4,6 @@ namespace eLife\ApiClient\ApiClient;
 
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
 
 final class AnnualReportsClient
 {
@@ -16,7 +14,7 @@ final class AnnualReportsClient
 
     public function getReport(array $headers, int $year) : PromiseInterface
     {
-        return $this->getRequest(Uri::fromParts(['path' => "annual-reports/$year"]), $headers);
+        return $this->getRequest($this->createUri(['path' => "annual-reports/$year"]), $headers);
     }
 
     public function listReports(
@@ -26,13 +24,13 @@ final class AnnualReportsClient
         bool $descendingOrder = true
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => 'annual-reports',
-                'query' => build_query(array_filter([
+                'query' => [
                     'page' => $page,
                     'per-page' => $perPage,
                     'order' => $descendingOrder ? 'desc' : 'asc',
-                ])),
+                ],
             ]),
             $headers
         );

--- a/src/ApiClient/ArticlesClient.php
+++ b/src/ApiClient/ArticlesClient.php
@@ -4,8 +4,6 @@ namespace eLife\ApiClient\ApiClient;
 
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
 
 final class ArticlesClient
 {
@@ -19,22 +17,22 @@ final class ArticlesClient
 
     public function getArticleLatestVersion(array $headers, string $number) : PromiseInterface
     {
-        return $this->getRequest(Uri::fromParts(['path' => "articles/$number"]), $headers);
+        return $this->getRequest($this->createUri(['path' => "articles/$number"]), $headers);
     }
 
     public function getArticleHistory(array $headers, string $number) : PromiseInterface
     {
-        return $this->getRequest(Uri::fromParts(['path' => "articles/$number/versions"]), $headers);
+        return $this->getRequest($this->createUri(['path' => "articles/$number/versions"]), $headers);
     }
 
     public function getRelatedArticles(array $headers, string $number) : PromiseInterface
     {
-        return $this->getRequest(Uri::fromParts(['path' => "articles/$number/related"]), $headers);
+        return $this->getRequest($this->createUri(['path' => "articles/$number/related"]), $headers);
     }
 
     public function getArticleVersion(array $headers, string $number, int $version) : PromiseInterface
     {
-        return $this->getRequest(Uri::fromParts(['path' => "articles/$number/versions/$version"]), $headers);
+        return $this->getRequest($this->createUri(['path' => "articles/$number/versions/$version"]), $headers);
     }
 
     public function listArticles(
@@ -45,14 +43,14 @@ final class ArticlesClient
         array $subjects = []
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => 'articles',
-                'query' => build_query(array_filter([
+                'query' => [
                     'page' => $page,
                     'per-page' => $perPage,
                     'order' => $descendingOrder ? 'desc' : 'asc',
                     'subject[]' => $subjects,
-                ])),
+                ],
             ]),
             $headers
         );

--- a/src/ApiClient/BlogClient.php
+++ b/src/ApiClient/BlogClient.php
@@ -4,8 +4,6 @@ namespace eLife\ApiClient\ApiClient;
 
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
 
 final class BlogClient
 {
@@ -16,7 +14,7 @@ final class BlogClient
 
     public function getArticle(array $headers, string $id) : PromiseInterface
     {
-        return $this->getRequest(Uri::fromParts(['path' => "blog-articles/$id"]), $headers);
+        return $this->getRequest($this->createUri(['path' => "blog-articles/$id"]), $headers);
     }
 
     public function listArticles(
@@ -27,14 +25,14 @@ final class BlogClient
         array $subjects = []
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => 'blog-articles',
-                'query' => build_query(array_filter([
+                'query' => [
                     'page' => $page,
                     'per-page' => $perPage,
                     'order' => $descendingOrder ? 'desc' : 'asc',
                     'subject[]' => $subjects,
-                ])),
+                ],
             ]),
             $headers
         );

--- a/src/ApiClient/CollectionsClient.php
+++ b/src/ApiClient/CollectionsClient.php
@@ -4,8 +4,6 @@ namespace eLife\ApiClient\ApiClient;
 
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
 
 final class CollectionsClient
 {
@@ -16,7 +14,7 @@ final class CollectionsClient
 
     public function getCollection(array $headers, string $id) : PromiseInterface
     {
-        return $this->getRequest(Uri::fromParts(['path' => "collections/$id"]), $headers);
+        return $this->getRequest($this->createUri(['path' => "collections/$id"]), $headers);
     }
 
     public function listCollections(
@@ -27,14 +25,14 @@ final class CollectionsClient
         array $subjects = []
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => 'collections',
-                'query' => build_query(array_filter([
+                'query' => [
                     'page' => $page,
                     'per-page' => $perPage,
                     'order' => $descendingOrder ? 'desc' : 'asc',
                     'subject[]' => $subjects,
-                ])),
+                ],
             ]),
             $headers
         );

--- a/src/ApiClient/CommunityClient.php
+++ b/src/ApiClient/CommunityClient.php
@@ -4,8 +4,6 @@ namespace eLife\ApiClient\ApiClient;
 
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
 
 final class CommunityClient
 {
@@ -21,14 +19,14 @@ final class CommunityClient
         array $subjects = []
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => 'community',
-                'query' => build_query(array_filter([
+                'query' => [
                     'page' => $page,
                     'per-page' => $perPage,
                     'order' => $descendingOrder ? 'desc' : 'asc',
                     'subject[]' => $subjects,
-                ])),
+                ],
             ]),
             $headers
         );

--- a/src/ApiClient/CoversClient.php
+++ b/src/ApiClient/CoversClient.php
@@ -5,8 +5,6 @@ namespace eLife\ApiClient\ApiClient;
 use DateTimeImmutable;
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
 
 final class CoversClient
 {
@@ -25,9 +23,9 @@ final class CoversClient
         DateTimeImmutable $ends = null
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => 'covers',
-                'query' => build_query(array_filter([
+                'query' => [
                     'page' => $page,
                     'per-page' => $perPage,
                     'sort' => $sort,
@@ -35,7 +33,7 @@ final class CoversClient
                     'use-date' => $useDate,
                     'start-date' => $starts ? $starts->format('Y-m-d') : null,
                     'end-date' => $ends ? $ends->format('Y-m-d') : null,
-                ])),
+                ],
             ]),
             $headers
         );
@@ -43,6 +41,6 @@ final class CoversClient
 
     public function listCurrentCovers(array $headers = []) : PromiseInterface
     {
-        return $this->getRequest(Uri::fromParts(['path' => 'covers/current']), $headers);
+        return $this->getRequest($this->createUri(['path' => 'covers/current']), $headers);
     }
 }

--- a/src/ApiClient/EventsClient.php
+++ b/src/ApiClient/EventsClient.php
@@ -4,8 +4,6 @@ namespace eLife\ApiClient\ApiClient;
 
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
 
 final class EventsClient
 {
@@ -16,7 +14,7 @@ final class EventsClient
 
     public function getEvent(array $headers, string $id) : PromiseInterface
     {
-        return $this->getRequest(Uri::fromParts(['path' => "events/$id"]), $headers);
+        return $this->getRequest($this->createUri(['path' => "events/$id"]), $headers);
     }
 
     public function listEvents(
@@ -27,14 +25,14 @@ final class EventsClient
         bool $descendingOrder = true
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => 'events',
-                'query' => build_query(array_filter([
+                'query' => [
                     'page' => $page,
                     'per-page' => $perPage,
                     'show' => $show,
                     'order' => $descendingOrder ? 'desc' : 'asc',
-                ])),
+                ],
             ]),
             $headers
         );

--- a/src/ApiClient/HighlightsClient.php
+++ b/src/ApiClient/HighlightsClient.php
@@ -4,8 +4,6 @@ namespace eLife\ApiClient\ApiClient;
 
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
 
 final class HighlightsClient
 {
@@ -21,13 +19,13 @@ final class HighlightsClient
         bool $descendingOrder = true
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => "highlights/$id",
-                'query' => build_query(array_filter([
+                'query' => [
                     'page' => $page,
                     'per-page' => $perPage,
                     'order' => $descendingOrder ? 'desc' : 'asc',
-                ])),
+                ],
             ]),
             $headers
         );

--- a/src/ApiClient/InterviewsClient.php
+++ b/src/ApiClient/InterviewsClient.php
@@ -4,8 +4,6 @@ namespace eLife\ApiClient\ApiClient;
 
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
 
 final class InterviewsClient
 {
@@ -16,7 +14,7 @@ final class InterviewsClient
 
     public function getInterview(array $headers, string $id) : PromiseInterface
     {
-        return $this->getRequest(Uri::fromParts(['path' => "interviews/$id"]), $headers);
+        return $this->getRequest($this->createUri(['path' => "interviews/$id"]), $headers);
     }
 
     public function listInterviews(
@@ -26,13 +24,13 @@ final class InterviewsClient
         bool $descendingOrder = true
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => 'interviews',
-                'query' => build_query(array_filter([
+                'query' => [
                     'page' => $page,
                     'per-page' => $perPage,
                     'order' => $descendingOrder ? 'desc' : 'asc',
-                ])),
+                ],
             ]),
             $headers
         );

--- a/src/ApiClient/LabsClient.php
+++ b/src/ApiClient/LabsClient.php
@@ -4,8 +4,6 @@ namespace eLife\ApiClient\ApiClient;
 
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
 
 final class LabsClient
 {
@@ -17,7 +15,7 @@ final class LabsClient
     public function getPost(array $headers, string $id) : PromiseInterface
     {
         return $this->getRequest(
-            Uri::fromParts(['path' => "labs-posts/$id"]),
+            $this->createUri(['path' => "labs-posts/$id"]),
             $headers
         );
     }
@@ -29,13 +27,13 @@ final class LabsClient
         bool $descendingOrder = true
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => 'labs-posts',
-                'query' => build_query(array_filter([
+                'query' => [
                     'page' => $page,
                     'per-page' => $perPage,
                     'order' => $descendingOrder ? 'desc' : 'asc',
-                ])),
+                ],
             ]),
             $headers
         );

--- a/src/ApiClient/MediumClient.php
+++ b/src/ApiClient/MediumClient.php
@@ -4,8 +4,6 @@ namespace eLife\ApiClient\ApiClient;
 
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
 
 final class MediumClient
 {
@@ -21,13 +19,13 @@ final class MediumClient
         bool $descendingOrder = true
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => 'medium-articles',
-                'query' => build_query(array_filter([
+                'query' => [
                     'page' => $page,
                     'per-page' => $perPage,
                     'order' => $descendingOrder ? 'desc' : 'asc',
-                ])),
+                ],
             ]),
             $headers);
     }

--- a/src/ApiClient/MetricsClient.php
+++ b/src/ApiClient/MetricsClient.php
@@ -4,8 +4,6 @@ namespace eLife\ApiClient\ApiClient;
 
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
 
 final class MetricsClient
 {
@@ -16,7 +14,7 @@ final class MetricsClient
 
     public function citations(array $headers, string $type, string $id) : PromiseInterface
     {
-        return $this->getRequest(Uri::fromParts(['path' => "metrics/$type/$id/citations"]), $headers);
+        return $this->getRequest($this->createUri(['path' => "metrics/$type/$id/citations"]), $headers);
     }
 
     public function downloads(
@@ -29,14 +27,14 @@ final class MetricsClient
         bool $descendingOrder = true
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => "metrics/$type/$id/downloads",
-                'query' => build_query(array_filter([
+                'query' => [
                     'by' => $by,
                     'page' => $page,
                     'per-page' => $perPage,
                     'order' => $descendingOrder ? 'desc' : 'asc',
-                ])),
+                ],
             ]),
             $headers);
     }
@@ -51,14 +49,14 @@ final class MetricsClient
         bool $descendingOrder = true
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => "metrics/$type/$id/page-views",
-                'query' => build_query(array_filter([
+                'query' => [
                     'by' => $by,
                     'page' => $page,
                     'per-page' => $perPage,
                     'order' => $descendingOrder ? 'desc' : 'asc',
-                ])),
+                ],
             ]),
             $headers);
     }

--- a/src/ApiClient/PeopleClient.php
+++ b/src/ApiClient/PeopleClient.php
@@ -4,8 +4,6 @@ namespace eLife\ApiClient\ApiClient;
 
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
 
 final class PeopleClient
 {
@@ -16,7 +14,7 @@ final class PeopleClient
 
     public function getPerson(array $headers, string $id) : PromiseInterface
     {
-        return $this->getRequest(Uri::fromParts(['path' => "people/$id"]), $headers);
+        return $this->getRequest($this->createUri(['path' => "people/$id"]), $headers);
     }
 
     public function listPeople(
@@ -28,15 +26,15 @@ final class PeopleClient
         string $type = null
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => 'people',
-                'query' => build_query(array_filter([
+                'query' => [
                     'page' => $page,
                     'per-page' => $perPage,
                     'order' => $descendingOrder ? 'desc' : 'asc',
                     'subject[]' => $subjects,
                     'type' => $type,
-                ])),
+                ],
             ]),
             $headers
         );

--- a/src/ApiClient/PodcastClient.php
+++ b/src/ApiClient/PodcastClient.php
@@ -4,8 +4,6 @@ namespace eLife\ApiClient\ApiClient;
 
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
 
 final class PodcastClient
 {
@@ -16,7 +14,7 @@ final class PodcastClient
 
     public function getEpisode(array $headers, int $number) : PromiseInterface
     {
-        return $this->getRequest(Uri::fromParts(['path' => "podcast-episodes/$number"]), $headers);
+        return $this->getRequest($this->createUri(['path' => "podcast-episodes/$number"]), $headers);
     }
 
     public function listEpisodes(
@@ -26,13 +24,13 @@ final class PodcastClient
         bool $descendingOrder = true
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => 'podcast-episodes',
-                'query' => build_query(array_filter([
+                'query' => [
                     'page' => $page,
                     'per-page' => $perPage,
                     'order' => $descendingOrder ? 'desc' : 'asc',
-                ])),
+                ],
             ]),
             $headers
         );

--- a/src/ApiClient/PressPackagesClient.php
+++ b/src/ApiClient/PressPackagesClient.php
@@ -4,8 +4,6 @@ namespace eLife\ApiClient\ApiClient;
 
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
 
 final class PressPackagesClient
 {
@@ -16,7 +14,7 @@ final class PressPackagesClient
 
     public function getPackage(array $headers, string $id) : PromiseInterface
     {
-        return $this->getRequest(Uri::fromParts(['path' => "press-packages/$id"]), $headers);
+        return $this->getRequest($this->createUri(['path' => "press-packages/$id"]), $headers);
     }
 
     public function listPackages(
@@ -27,14 +25,14 @@ final class PressPackagesClient
         array $subjects = []
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => 'press-packages',
-                'query' => build_query(array_filter([
+                'query' => [
                     'page' => $page,
                     'per-page' => $perPage,
                     'order' => $descendingOrder ? 'desc' : 'asc',
                     'subject[]' => $subjects,
-                ])),
+                ],
             ]),
             $headers
         );

--- a/src/ApiClient/RecommendationsClient.php
+++ b/src/ApiClient/RecommendationsClient.php
@@ -4,8 +4,6 @@ namespace eLife\ApiClient\ApiClient;
 
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
 
 final class RecommendationsClient
 {
@@ -22,13 +20,13 @@ final class RecommendationsClient
         bool $descendingOrder = true
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => "recommendations/$type/$id",
-                'query' => build_query(array_filter([
+                'query' => [
                     'page' => $page,
                     'per-page' => $perPage,
                     'order' => $descendingOrder ? 'desc' : 'asc',
-                ])),
+                ],
             ]),
             $headers
         );

--- a/src/ApiClient/SearchClient.php
+++ b/src/ApiClient/SearchClient.php
@@ -6,7 +6,7 @@ use DateTimeImmutable;
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
+use function GuzzleHttp\Psr7\parse_query;
 
 final class SearchClient
 {
@@ -27,22 +27,26 @@ final class SearchClient
         DateTimeImmutable $starts = null,
         DateTimeImmutable $ends = null
     ) : PromiseInterface {
-        return $this->getRequest(
-            Uri::fromParts([
-                'path' => 'search',
-                'query' => build_query(['for' => $query] + array_filter([
-                    'page' => $page,
-                    'per-page' => $perPage,
-                    'sort' => $sort,
-                    'order' => $descendingOrder ? 'desc' : 'asc',
-                    'subject[]' => $subjects,
-                    'type[]' => $types,
-                    'use-date' => $useDate,
-                    'start-date' => $starts ? $starts->format('Y-m-d') : null,
-                    'end-date' => $ends ? $ends->format('Y-m-d') : null,
-                ])),
-            ]),
-            $headers
-        );
+        $uri = $this->createUri([
+            'path' => 'search',
+            'query' => [
+                'for' => $query,
+                'page' => $page,
+                'per-page' => $perPage,
+                'sort' => $sort,
+                'order' => $descendingOrder ? 'desc' : 'asc',
+                'subject[]' => $subjects,
+                'type[]' => $types,
+                'use-date' => $useDate,
+                'start-date' => $starts ? $starts->format('Y-m-d') : null,
+                'end-date' => $ends ? $ends->format('Y-m-d') : null,
+            ],
+        ]);
+
+        if (!isset(parse_query($uri->getQuery())['for'])) {
+            $uri = Uri::withQueryValue($uri, 'for', $query);
+        }
+
+        return $this->getRequest($uri, $headers);
     }
 }

--- a/src/ApiClient/SearchClient.php
+++ b/src/ApiClient/SearchClient.php
@@ -5,7 +5,6 @@ namespace eLife\ApiClient\ApiClient;
 use DateTimeImmutable;
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
 use function GuzzleHttp\Psr7\parse_query;
 
 final class SearchClient
@@ -44,7 +43,7 @@ final class SearchClient
         ]);
 
         if (!isset(parse_query($uri->getQuery())['for'])) {
-            $uri = Uri::withQueryValue($uri, 'for', $query);
+            $uri = $uri->withQuery('for=&'.$uri->getQuery());
         }
 
         return $this->getRequest($uri, $headers);

--- a/src/ApiClient/SubjectsClient.php
+++ b/src/ApiClient/SubjectsClient.php
@@ -4,8 +4,6 @@ namespace eLife\ApiClient\ApiClient;
 
 use eLife\ApiClient\ApiClient;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\build_query;
 
 final class SubjectsClient
 {
@@ -16,7 +14,7 @@ final class SubjectsClient
 
     public function getSubject(array $headers, string $id) : PromiseInterface
     {
-        return $this->getRequest(Uri::fromParts(['path' => "subjects/$id"]), $headers);
+        return $this->getRequest($this->createUri(['path' => "subjects/$id"]), $headers);
     }
 
     public function listSubjects(
@@ -26,13 +24,13 @@ final class SubjectsClient
         bool $descendingOrder = true
     ) : PromiseInterface {
         return $this->getRequest(
-            Uri::fromParts([
+            $this->createUri([
                 'path' => 'subjects',
-                'query' => build_query(array_filter([
+                'query' => [
                     'page' => $page,
                     'per-page' => $perPage,
                     'order' => $descendingOrder ? 'desc' : 'asc',
-                ])),
+                ],
             ]),
             $headers
         );


### PR DESCRIPTION
Currently characters like '%' and '/' are encoded, which make things harder to work with downstream (when mocking, as you also then have to percent-encode).