### PR TITLE
Solve PHPUnit warnings over getMock() deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "phpspec/phpspec": "^2.4",
         "phpspec/prophecy": "^1.5",
         "phpunit/phpunit": "^5.7.1",
+        "sebastian/exporter": "^2.0.0",
         "psr/log": "^1.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "phpspec/phpspec": "^2.4",
         "phpspec/prophecy": "^1.5",
         "phpunit/phpunit": "^5.7.2",
+        "sebastian/exporter": "^2.0.0",
         "psr/log": "^1.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "giorgiosironi/eris": "^0.8",
+        "giorgiosironi/eris": "^0.9",
         "guzzlehttp/guzzle": "^6.0",
         "mtdowling/jmespath.php": "^2.0",
         "phpspec/phpspec": "^2.4",
         "phpspec/prophecy": "^1.5",
-        "phpunit/phpunit": "^5.2",
+        "phpunit/phpunit": "^5.7.1",
         "psr/log": "^1.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
         "mtdowling/jmespath.php": "^2.0",
         "phpspec/phpspec": "^2.4",
         "phpspec/prophecy": "^1.5",
-        "phpunit/phpunit": "^5.7.1",
-        "sebastian/exporter": "^2.0.0",
+        "phpunit/phpunit": "^5.7.2",
         "psr/log": "^1.0"
     },
     "suggest": {

--- a/test/HttpClient/BatchingHttpClientTest.php
+++ b/test/HttpClient/BatchingHttpClientTest.php
@@ -21,7 +21,7 @@ class BatchingHttpClientTest extends PHPUnit_Framework_TestCase
 
     public function testRandomSequenceOfSendAndWaits()
     {
-        $originalClient = $this->getMock(HttpClient::class);
+        $originalClient = $this->createMock(HttpClient::class);
         $originalClient
             ->expects($this->any())
             ->method('send')

--- a/test/HttpClient/BatchingHttpClientTest.php
+++ b/test/HttpClient/BatchingHttpClientTest.php
@@ -7,7 +7,7 @@ use Eris\TestTrait;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use function Eris\Generator\bind;
 use function Eris\Generator\choose;
 use function Eris\Generator\constant;
@@ -15,7 +15,7 @@ use function Eris\Generator\map;
 use function Eris\Generator\tuple;
 use function Eris\Generator\vector;
 
-class BatchingHttpClientTest extends PHPUnit_Framework_TestCase
+class BatchingHttpClientTest extends TestCase
 {
     use TestTrait;
 

--- a/test/HttpClient/ForbiddingHttpClientTest.php
+++ b/test/HttpClient/ForbiddingHttpClientTest.php
@@ -4,9 +4,9 @@ namespace eLife\ApiClient\HttpClient;
 
 use eLife\ApiClient\Exception\UnintendedInteraction;
 use GuzzleHttp\Psr7\Request;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-final class ForbiddingHttpClientTest extends PHPUnit_Framework_TestCase
+final class ForbiddingHttpClientTest extends TestCase
 {
     /**
      * @test

--- a/test/HttpClient/Guzzle6HttpClientTest.php
+++ b/test/HttpClient/Guzzle6HttpClientTest.php
@@ -19,11 +19,11 @@ use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Traversable;
 use function GuzzleHttp\default_user_agent;
 
-final class Guzzle6HttpClientTest extends PHPUnit_Framework_TestCase
+final class Guzzle6HttpClientTest extends TestCase
 {
     private $mock;
     private $history;

--- a/test/HttpClient/NotifyingHttpClientTest.php
+++ b/test/HttpClient/NotifyingHttpClientTest.php
@@ -6,11 +6,11 @@ use eLife\ApiClient\HttpClient;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use function GuzzleHttp\Promise\promise_for;
 
-final class NotifyingHttpClientTest extends PHPUnit_Framework_TestCase
+final class NotifyingHttpClientTest extends TestCase
 {
     private $mock;
     private $guzzle;

--- a/test/HttpClient/NotifyingHttpClientTest.php
+++ b/test/HttpClient/NotifyingHttpClientTest.php
@@ -19,7 +19,7 @@ final class NotifyingHttpClientTest extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->originalClient = $this->getMock(HttpClient::class);
+        $this->originalClient = $this->createMock(HttpClient::class);
         $this->client = new NotifyingHttpClient($this->originalClient);
     }
 

--- a/test/HttpClient/UserAgentPrependingHttpClientTest.php
+++ b/test/HttpClient/UserAgentPrependingHttpClientTest.php
@@ -4,11 +4,11 @@ namespace eLife\ApiClient\HttpClient;
 
 use eLife\ApiClient\HttpClient;
 use GuzzleHttp\Psr7\Request;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Traversable;
 
-final class UserAgentPrependingHttpClientTest extends PHPUnit_Framework_TestCase
+final class UserAgentPrependingHttpClientTest extends TestCase
 {
     private $originalClient;
     private $requests;

--- a/test/HttpClient/UserAgentPrependingHttpClientTest.php
+++ b/test/HttpClient/UserAgentPrependingHttpClientTest.php
@@ -20,7 +20,7 @@ final class UserAgentPrependingHttpClientTest extends PHPUnit_Framework_TestCase
     {
         $this->requests = [];
 
-        $this->originalClient = new NotifyingHttpClient($this->getMock(HttpClient::class));
+        $this->originalClient = new NotifyingHttpClient($this->createMock(HttpClient::class));
 
         $this->originalClient->addRequestListener(function (RequestInterface $request) {
             $this->requests[] = $request;

--- a/test/Log/HttpMessageProcessorTest.php
+++ b/test/Log/HttpMessageProcessorTest.php
@@ -6,9 +6,9 @@ use eLife\ApiClient\Exception\BadResponse;
 use eLife\ApiClient\Exception\NetworkProblem;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class HttpMessageProcessorTest extends PHPUnit_Framework_TestCase
+class HttpMessageProcessorTest extends TestCase
 {
     public function setUp()
     {

--- a/test/MediaTypeTest.php
+++ b/test/MediaTypeTest.php
@@ -4,9 +4,9 @@ namespace test\eLife\ApiClient;
 
 use eLife\ApiClient\MediaType;
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-final class MediaTypeTest extends PHPUnit_Framework_TestCase
+final class MediaTypeTest extends TestCase
 {
     /**
      * @test

--- a/test/Result/HttpResultTest.php
+++ b/test/Result/HttpResultTest.php
@@ -4,11 +4,11 @@ namespace test\eLife\ApiClient\Result;
 
 use eLife\ApiClient\Result\HttpResult;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TypeError;
 use UnexpectedValueException;
 
-final class HttpResultTest extends PHPUnit_Framework_TestCase
+final class HttpResultTest extends TestCase
 {
     /**
      * @test


### PR DESCRIPTION
New, but allowed versions of PHPUnit give these warnings when running
the tests:
```
PHPUnit_Framework_TestCase::getMock() is deprecated, use
PHPUnit_Framework_TestCase::createMock() or
PHPUnit_Framework_TestCase::getMockBuilder() instead
```