### PR TITLE
Bump minimum version of Prophecy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,6 @@ elifeLibrary {
     checkout scm
 
     elifeVariants(['lowest', 'default'], { dependencies ->
-        elifeLocalTests "dependencies=${dependencies} ./project_tests.sh", ["build/${dependencies}-phpspec.xml", "build/${dependencies}-phpunit.xml"]
+        elifeLocalTests "dependencies=${dependencies} ./project_tests.sh", ["build/${dependencies}-phpunit.xml"]
     })
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "guzzlehttp/guzzle": "^6.0",
         "mtdowling/jmespath.php": "^2.0",
         "phpspec/phpspec": "^2.4",
-        "phpspec/prophecy": "^1.5",
+        "phpspec/prophecy": "^1.10",
         "phpunit/phpunit": "^5.2",
         "psr/log": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
         "phpunit/phpunit": "^5.2",
         "psr/log": "^1.0"
     },
+    "conflict": {
+        "sebastian/comparator": "<1.2.3"
+    },
     "suggest": {
         "guzzlehttp/guzzle": "^6.0, to use the Guzzle6HttpClient adapter",
         "mtdowling/jmespath.php": "^2.0, to use the Result::search() method",

--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,6 @@
         "phpunit/phpunit": "^5.2",
         "psr/log": "^1.0"
     },
-    "conflict": {
-        "sebastian/comparator": "<1.2.3"
-    },
     "suggest": {
         "guzzlehttp/guzzle": "^6.0, to use the Guzzle6HttpClient adapter",
         "mtdowling/jmespath.php": "^2.0, to use the Result::search() method",

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -8,5 +8,5 @@ if [ "$dependencies" = "lowest" ]; then
 else
     composer update --no-interaction
 fi
-(vendor/bin/phpspec run --format=junit | tee build/${dependencies}-phpspec.xml) && echo "PHPSpec tests passed - see build/phpspec.xml log"
+vendor/bin/phpspec run
 vendor/bin/phpunit --log-junit="build/${dependencies}-phpunit.xml"


### PR DESCRIPTION
Ensures https://github.com/sebastianbergmann/comparator/pull/30 is available so the `prefer-lowest` tests work on newer versions of PHP. Refs https://github.com/elifesciences/issues/issues/5398.