### PR TITLE
Stop testing the library with the lowest dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,19 +17,17 @@ jobs:
     strategy:
       matrix:
         php_version: [7.1, 7.2, 7.3, 7.4]
-        task: ['test', 'test-lowest']
     steps:
       - uses: actions/checkout@v4
       - name: Run tests
-        run: make PHP_VERSION=${{ matrix.php_version }} ${{ matrix.task }}
+        run: make PHP_VERSION=${{ matrix.php_version }} test
   tests-future-versions:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         php_version: [8.0, 8.1, 8.2, 8.3]
-        task: ['test', 'test-lowest']
     steps:
       - uses: actions/checkout@v4
       - name: Run tests against all major versions of PHP
-        run: make PHP_VERSION=${{ matrix.php_version }} ${{ matrix.task }}
+        run: make PHP_VERSION=${{ matrix.php_version }} test
         continue-on-error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: [7.1, 7.2, 7.3, 7.4]
+        php_version: ["7.1", "7.2", "7.3", "7.4"]
     steps:
       - uses: actions/checkout@v4
       - name: Run tests
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: [8.0, 8.1, 8.2, 8.3]
+        php_version: ["8.0", "8.1", "8.2", "8.3"]
     steps:
       - uses: actions/checkout@v4
       - name: Run tests against all major versions of PHP

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG PHP_VERSION=7.4
-FROM php:${PHP_VERSION}-cli
+ARG PHP_VERSION=latest
+FROM php:${PHP_VERSION}
 
 RUN apt-get update && apt-get install -y git unzip && rm -rf /var/lib/apt/lists/*
 COPY --from=composer:2.2 /usr/bin/composer /usr/bin/composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 ARG PHP_VERSION=7.4
-FROM php:${PHP_VERSION}
+FROM php:${PHP_VERSION}-cli
 
 RUN apt-get update && apt-get install -y git unzip && rm -rf /var/lib/apt/lists/*
 COPY --from=composer:2.2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /code
+
+COPY composer.json composer.json
+RUN composer install
+
+COPY . .

--- a/Makefile
+++ b/Makefile
@@ -4,31 +4,27 @@ build:
 	docker buildx build --build-arg=PHP_VERSION=$(PHP_VERSION) -t php-composer:$(PHP_VERSION) .
 
 lint: build
-	docker run --rm -v ./:/code -v/code/vendor php-composer:$(PHP_VERSION) bash -c 'cd /code && composer update && vendor/bin/phpcs --standard=phpcs.xml.dist --warning-severity=0 -p src/ test/'
+	docker run --rm -v ./:/code -v/code/vendor php-composer:$(PHP_VERSION) bash -c 'vendor/bin/phpcs --standard=phpcs.xml.dist --warning-severity=0 -p src/ test/'
 
 test: build lint
-	docker run --rm -v ./:/code -e dependencies=highest -v/code/vendor php-composer:$(PHP_VERSION) bash -c 'cd /code && composer update && ./project_tests.sh'
-
-test-lowest: build lint
-	docker run --rm -v ./:/code -e dependencies=lowest -v/code/vendor php-composer:$(PHP_VERSION) bash -c 'cd /code && ./project_tests.sh'
-
+	docker run --rm -v ./:/code -e dependencies=highest -v/code/vendor php-composer:$(PHP_VERSION) bash -c './project_tests.sh'
 
 test-7.1:
-	@$(MAKE) PHP_VERSION=7.1 test test-lowest
+	@$(MAKE) PHP_VERSION=7.1 test
 test-7.2:
-	@$(MAKE) PHP_VERSION=7.2 test test-lowest
+	@$(MAKE) PHP_VERSION=7.2 test
 test-7.3:
-	@$(MAKE) PHP_VERSION=7.3 test test-lowest
+	@$(MAKE) PHP_VERSION=7.3 test
 test-7.4:
-	@$(MAKE) PHP_VERSION=7.4 test test-lowest
+	@$(MAKE) PHP_VERSION=7.4 test
 test-8.0:
-	@$(MAKE) PHP_VERSION=8.0 test test-lowest
+	@$(MAKE) PHP_VERSION=8.0 test
 test-8.1:
-	@$(MAKE) PHP_VERSION=8.1 test test-lowest
+	@$(MAKE) PHP_VERSION=8.1 test
 test-8.2:
-	@$(MAKE) PHP_VERSION=8.2 test test-lowest
+	@$(MAKE) PHP_VERSION=8.2 test
 test-8.3:
-	@$(MAKE) PHP_VERSION=8.3 test test-lowest
+	@$(MAKE) PHP_VERSION=8.3 test
 
 test-all: test-7.1 test-7.2 test-7.3 test-7.4 test-8.0 test-8.1 test-8.2 test-8.3
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ lint: build
 	docker run --rm -v ./:/code -v/code/vendor php-composer:$(PHP_VERSION) bash -c 'vendor/bin/phpcs --standard=phpcs.xml.dist --warning-severity=0 -p src/ test/'
 
 test: build lint
-	docker run --rm -v ./:/code -e dependencies=highest -v/code/vendor php-composer:$(PHP_VERSION) bash -c './project_tests.sh'
+	docker run --rm -v ./:/code -v/code/vendor php-composer:$(PHP_VERSION) bash -c './project_tests.sh'
 
 test-7.1:
 	@$(MAKE) PHP_VERSION=7.1 test

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 set -e
 
-: "${dependencies:?Need to set dependencies environment variable}"
-if [ "$dependencies" = "lowest" ]; then
-    composer update --prefer-lowest --no-interaction
-    vendor/bin/phpcs --standard=phpcs.xml.dist --warning-severity=0 -p spec/ src/ test/
-else
-    composer update --no-interaction
-fi
 vendor/bin/phpspec run
 vendor/bin/phpunit --log-junit="build/${dependencies}-phpunit.xml"


### PR DESCRIPTION
While the goal is laudable, by we arbitrarily restrict the window of supported versions of PHP by allowing the lowest supported versions of a library's dependency (which may have an even lower ceiling than us) to dictate our maximum supported version via the test suite.

Since we're now testing against multiple versions of PHP, that will provide a better show of our range of supported PHP versions, and it's down to consuming libraries to make sure they are compatible with any sub-dependency requirements